### PR TITLE
Encode unicode characters to ASCII for Python 2 unicode support

### DIFF
--- a/stringcase.py
+++ b/stringcase.py
@@ -133,8 +133,13 @@ def sentencecase(string):
         string: Sentence cased string.
 
     """
+    try:
+        string = str(string)
+    except UnicodeEncodeError:
+        string = string.encode('ascii', 'ignore')
+
     joiner = ' '
-    string = re.sub(r"[\-_\.\s]", joiner, str(string))
+    string = re.sub(r"[\-_\.\s]", joiner, string)
     if not string:
         return string
     return capitalcase(trimcase(
@@ -154,8 +159,12 @@ def snakecase(string):
         string: Snake cased string.
 
     """
+    try:
+        string = str(string)
+    except UnicodeEncodeError:
+        string = string.encode('ascii', 'ignore')
 
-    string = re.sub(r"[\-\.\s]", '_', str(string))
+    string = re.sub(r"[\-\.\s]", '_', string)
     if not string:
         return string
     return lowercase(string[0]) + re.sub(r"[A-Z]", lambda matched: '_' + lowercase(matched.group(0)), string[1:])

--- a/stringcase.py
+++ b/stringcase.py
@@ -7,6 +7,7 @@ import re
 
 def camelcase(string):
     """ Convert string into camel case.
+    Except UnicodeEncodeErrors for Python 2 unicode character support.
 
     Args:
         string: String to convert.
@@ -15,8 +16,12 @@ def camelcase(string):
         string: Camel case string.
 
     """
+    try:
+        string = str(string)
+    except UnicodeEncodeError:
+        string = string.encode('ascii', 'ignore')
 
-    string = re.sub(r"^[\-_\.]", '', str(string))
+    string = re.sub(r"^[\-_\.]", '', string)
     if not string:
         return string
     return lowercase(string[0]) + re.sub(r"[\-_\.\s]([a-z])", lambda matched: uppercase(matched.group(1)), string[1:])

--- a/stringcase.py
+++ b/stringcase.py
@@ -125,6 +125,7 @@ def backslashcase(string):
 def sentencecase(string):
     """Convert string into sentence case.
     First letter capped and each punctuations are joined with space.
+    Except UnicodeEncodeErrors for Python 2 unicode character support.
 
     Args:
         string: String to convert.
@@ -151,6 +152,7 @@ def sentencecase(string):
 def snakecase(string):
     """Convert string into snake case.
     Join punctuation with underscore
+    Except UnicodeEncodeErrors for Python 2 unicode character support.
 
     Args:
         string: String to convert.

--- a/stringcase_test.py
+++ b/stringcase_test.py
@@ -101,6 +101,13 @@ class StringcaseTest(TestCase):
         eq('', sentencecase(''))
         eq('None', sentencecase(None))
 
+    def test_sentencecase_unicode_character(self):
+        from stringcase import sentencecase
+
+        eq = self.assertEqual
+
+        eq('Foo Bar', sentencecase(u'foo_bar\u2728'))
+
     def test_uppercase(self):
         from stringcase import uppercase
 
@@ -123,6 +130,13 @@ class StringcaseTest(TestCase):
         eq('_bar_baz', snakecase('.bar_baz'))
         eq('', snakecase(''))
         eq('none', snakecase(None))
+
+    def test_sentencecase_unicode_character(self):
+        from stringcase import snakecase
+
+        eq = self.assertEqual
+
+        eq('foo_bar', snakecase(u'fooBar\u2728'))
 
     def test_spinalcase(self):
         from stringcase import spinalcase

--- a/stringcase_test.py
+++ b/stringcase_test.py
@@ -23,6 +23,13 @@ class StringcaseTest(TestCase):
         eq('', camelcase(''))
         eq('none', camelcase(None))
 
+    def test_camelcase_unicode_character(self):
+        from stringcase import camelcase
+
+        eq = self.assertEqual
+
+        eq('fooBar', camelcase(u'foo_bar\u2728'))
+
     def test_capitalcase(self):
         from stringcase import capitalcase
 


### PR DESCRIPTION
fixes #1 

## Problem

When converting cases in Python 2 when the data has a unicode character in it, you will get this `UnicodeEncodeError`:

```
UnicodeEncodeError: 'ascii' codec can't encode character u'\uXXXX' in position 4: ordinal not in range(128)
```

## Solution

`Try/except` converting the input to a string with `str`. If a `UnicodeEncodeError` is raised then encode the string to 'ascii' and continue.